### PR TITLE
gulpfile improvements_levels & order

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,8 +10,8 @@ const rename = require('gulp-rename');
 const clean = require('gulp-clean');
 const autoprefixer = require('gulp-autoprefixer');
 const imagemin = require('gulp-imagemin');
-const notify = require('gulp-notify');
-const plumber = require('gulp-plumber');
+// const notify = require('gulp-notify');
+// const plumber = require('gulp-plumber');
 
 
 
@@ -26,54 +26,42 @@ gulp.task('clean', function () {
 
 gulp.task('styles', function () {
     return gulp.src('src/scss/style.scss')
-        // .pipe(notify('Notify: FOUND ERROR in file: style.scss'))
-        // .pipe(plumber({errorHandler: notify.onError("Plumber: FOUND ERROR in file: style.scss")}))
-        // .pipe(through(function () {
-        //     this.emit("error", new Error("Something happend: Plumber found ERROR"))
-        // }))
-        .pipe(browserSync.reload({stream: true}))
-        // .pipe(sass({outputStyle: 'expanded'}).on('error', notify('Notify: FOUND ERROR in file: style.scss')))
-        .pipe(sass({outputStyle: 'expanded'}).on('error', sass.logError))
-        .pipe(autoprefixer({
-            overrideBrowserslist: ['last 5 versions'],
-            cascade: false
-        }))
-        .pipe(gulp.dest('src/scss/'))
-        .pipe(cleanCss())
-        .pipe(rename({
+    .pipe(sass({outputStyle: 'expanded'}).on('error', sass.logError))
+    .pipe(autoprefixer({
+        overrideBrowserslist: ['> 0.1%'],
+        cascade: false
+    }))
+    .pipe(gulp.dest('src/scss/'))
+    .pipe(cleanCss({
+        level: 2
+    }))
+    .pipe(rename({
             suffix: '.min'
         }))
         .pipe(gulp.dest('dist/css/'))
+        .pipe(browserSync.reload({stream: true}))
 });
 
 /*********** SCRIPTS PROCESSING **********/
 
 gulp.task('scripts', function () {
     return gulp.src('src/js/sections/**/*.js')
-        // .pipe(notify('Notify: FOUND ERROR in SCRIPT files in forlder: src/js/sections/**/*.js'))
-        // .pipe(plumber({errorHandler: notify.onError("Plumber: FOUND ERROR in SCRIPT files in forlder: src/js/sections/**/*.js")}))
-        // .pipe(through(function () {
-        //     this.emit("error", new Error("Something happend: Plumber found ERROR"))
-        // }))
-        .pipe(browserSync.reload({stream: true}))
         .pipe(concat('index.js'))
         .pipe(gulp.dest('src/js/'))
-        .pipe(uglify())
+        .pipe(uglify({
+            toplevel: true
+        }))
         .pipe(rename('script.min.js'))
         .pipe(gulp.dest('dist/js/'))
+        .pipe(browserSync.reload({stream: true}))
 });
 
 gulp.task('script-libs', function () {
     return gulp.src('src/js/libs/**/*.js')
-        // .pipe(notify('Notify: FOUND ERROR in SCRIPT files in forlder: src/js/libs/**/*.js'))
-        // .pipe(plumber({errorHandler: notify.onError("Plumber: FOUND ERROR in SCRIPT files in forlder: src/js/lips/**/*.js")}))
-        // .pipe(through(function () {
-        //     this.emit("error", new Error("Something happend: Plumber found ERROR"))
-        // }))
-        .pipe(browserSync.reload({stream: true}))
         .pipe(concat('script-libs.min.js'))
         .pipe(uglify())
         .pipe(gulp.dest('dist/js/'))
+        .pipe(browserSync.reload({stream: true}))
 });
 
 
@@ -83,6 +71,7 @@ gulp.task('image-min', function () {
     return gulp.src('src/img/**/*.*')
         .pipe(imagemin())
         .pipe(gulp.dest('dist/img/'))
+        .pipe(browserSync.reload({stream: true}))
 });
 
 
@@ -90,10 +79,11 @@ gulp.task('image-min', function () {
 /*********** Browser Sync **********/
 
 gulp.task('browser-sync', function () {
-    browserSync({
+    browserSync.init({
         server: {
             baseDir: './'
-        }
+        },
+        tunnel: true
     });
 });
 
@@ -109,7 +99,9 @@ gulp.task('watch', function () {
 
 /*********** Main Tasks **********/
 
-gulp.task('build', gulp.series('clean', 'styles', 'scripts', 'script-libs', 'image-min'));
-gulp.task('dev', gulp.parallel('watch', 'browser-sync'));
+gulp.task('build', gulp.series('clean',
+                    gulp.parallel('styles', 'scripts', 'script-libs', 'image-min')));
+
+gulp.task('dev', gulp.parallel('browser-sync', 'watch'));
 
 


### PR DESCRIPTION
changes:
- task styles: changed autoprefixer (browsers>0.1%);
- task styles: added level:2 to cleanCss;
- task stcripts: added toplevel:true to uglify;
- task browserSync, added tunnel:true;
- browserSync.reload is moved to the end of pipe in all tasks;
- task build: clean goes first, then others parallel;
